### PR TITLE
GV post-filter has been implemented

### DIFF
--- a/scripts/src/convert.py
+++ b/scripts/src/convert.py
@@ -53,8 +53,8 @@ def main():
     # read F0 transfomer
     orgf0statspath = pconf.pairdir + '/stats/org.f0stats'
     tarf0statspath = pconf.pairdir + '/stats/tar.f0stats'
-    f0trans = F0statistics(pconf)
-    f0trans.read_statistics(orgf0statspath, tarf0statspath)
+    f0stats = F0statistics(pconf)
+    f0stats.read_statistics(orgf0statspath, tarf0statspath)
 
     # read GMM for mcep
     mcepgmmpath = pconf.pairdir + '/model/GMM.pkl'
@@ -87,7 +87,7 @@ def main():
         apperiodicity = h5.read('ap')
 
         # convert F0
-        cvf0 = f0trans.transform_f0(f0)
+        cvf0 = f0stats.convert_f0(f0)
 
         # TODO: convert band-aperiodicity
         # cvbap = bapgmm.convert(calculate_delta(bap))
@@ -101,7 +101,7 @@ def main():
         wavfile.write(wavpath, sconf.fs, np.array(wav, dtype=np.int16))
 
         # conversion w/ GV
-        cvmcep_wopow_wGV = mcepgv.gv_postfilter(cvmcep_wopow, sd=1)
+        cvmcep_wopow_wGV = mcepgv.apply_gvpostfilter(cvmcep_wopow, startdim=1)
         cvmcep_wGV = np.c_[mcep_0th, cvmcep_wopow_wGV]
         wav_wGV = synthesizer.synthesis(cvf0, cvmcep_wGV, apperiodicity)
         wav_wGVpath = testdir + '/' + h5.flbl + '_cv_wGV.wav'

--- a/sprocket/stats/f0statistics.py
+++ b/sprocket/stats/f0statistics.py
@@ -75,21 +75,21 @@ class F0statistics (object):
 
         return
 
-    def transform_f0(self, if0):
+    def convert_f0(self, f0):
         assert self.omean, self.ostd is not None
         assert self.tmean, self.tstdis is not None
 
         # get length and dimension
-        T = len(if0)
+        T = len(f0)
 
-        # perform f0 transformation
-        of0 = np.zeros(T)
-        for t in range(T):
-            if if0[t] > 0:
-                of0[t] = (if0[t] - self.omean) * \
-                    self.tstd / self.ostd + self.tmean
+        # perform f0 conversion
+        cvf0 = np.zeros(T)
 
-        return of0
+        nonzero_indices = f0 > 0
+        cvf0[nonzero_indices] = (f0[nonzero_indices] - self.omean) * \
+            self.tstd / self.ostd + self.tmean
+
+        return cvf0
 
 
 def main():

--- a/sprocket/stats/gv.py
+++ b/sprocket/stats/gv.py
@@ -72,24 +72,21 @@ class GV (object):
         self.gv = gv.reshape(2, dim)
         return
 
-    def gv_postfilter(self, data, sd=1):
+    def apply_gvpostfilter(self, data, startdim=1):
         # get length and dimension
         T, dim = data.shape
         assert self.gv is not None
-        assert dim + sd == self.gv.shape[1]
+        assert dim + startdim == self.gv.shape[1]
 
         # calculate statics of input data
-        datamean = np.average(data, axis=0)
+        datamean = np.mean(data, axis=0)
         datavar = np.var(data, axis=0)
 
         # perform GV postfilter
-        odata = np.zeros((T, dim))
-        for t in range(T):
-            for d in range(dim):
-                odata[t, d] = np.sqrt(self.gv[0, d + sd] / datavar[d]) * \
-                    (data[t, d] - datamean[d]) + datamean[d]
+        filtered_data = np.sqrt(self.gv[0, startdim:] / datavar) * \
+            (data - datamean) + datamean
 
-        return odata
+        return filtered_data
 
 
 def main():


### PR DESCRIPTION
#7 GV postfilterを実装した．
- targetのGV statsをGV classで読み込み，引数にdataを投げるとGVが補償されたodataが返されてくる．
- 0-thのmcepには基本的にGVを補償しない（GMMで変換しないため）
- デバッグとして，gv_postfilterで生成されたodataの分散とGVの分散の平均（GV.gv[0, d + sd]）がほぼ一致する事を確認した．
- gvpf後のmcepで波形合成してみたが，GVなしとの違いがあまりわからなかった．（mmseのせい？ or aperiodicityが影響を与えてる or MLSAフィルタじゃない）