### PR TITLE
Pythonスクリプトのshebangの修正

### DIFF
--- a/example/src/convert.py
+++ b/example/src/convert.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # convert.py

--- a/example/src/estimate_feature_statistics.py
+++ b/example/src/estimate_feature_statistics.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # estimate_feature_statistics.py

--- a/example/src/estimate_twf_and_jnt.py
+++ b/example/src/estimate_twf_and_jnt.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # estimate_jnt.py

--- a/example/src/extract_features.py
+++ b/example/src/extract_features.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # extract_features.py

--- a/example/src/f0_transformation.py
+++ b/example/src/f0_transformation.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # F0_transformation.py

--- a/example/src/initialize_pair.py
+++ b/example/src/initialize_pair.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # init_pair.py

--- a/example/src/initialize_speaker.py
+++ b/example/src/initialize_speaker.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # init_spkr.py

--- a/example/src/test.py
+++ b/example/src/test.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # test.py

--- a/example/src/train_GMM.py
+++ b/example/src/train_GMM.py
@@ -1,4 +1,4 @@
-#! /usr/local/bin/python
+#! /usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # train_GMM.py


### PR DESCRIPTION
shebangが`#! /usr/local/python`となっているスクリプトが多く見受けられますが、すべての人が`/usr/local/python`にメインのPythonを置いているとは限らないため、`#! /usr/bin/env python`に修正しました。