### PR TITLE
Remove Python 2.7 dependency in examples and import future

### DIFF
--- a/example/download_vcc2016data.py
+++ b/example/download_vcc2016data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Downloader of sample audio data of The Voice Conversion Challenge (VCC) 2016
 
@@ -19,21 +19,14 @@ Arguments:
     -m, --minimal   Exit when there are some directories in data/wav
 """
 
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
-import errno
 import os
 import shutil
-import sys
-from glob import iglob
-from tempfile import mkdtemp
-from zipfile import ZipFile
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
-import six
 from docopt import docopt
-
-from six.moves import filter, urllib
 
 
 def download(url, dest=None):
@@ -56,104 +49,16 @@ def download(url, dest=None):
     urllib.error.HTTPError
         When `the status code is not 200 or 30*.
     """
-    # Support for 2.7
-    try:
-        request_obj = urllib.request.urlopen(url)
-    # end
-    # with urllib.request.urlopen(url) as request_obj:
+    with urllib.request.urlopen(url) as request_obj:
         real_file_name = os.path.basename(
             urllib.parse.urlparse(request_obj.geturl()).path)
         if dest is None:
             dest = real_file_name
-        elif os.path.isdir(dest):
-            dest = os.path.join(dest, real_file_name)
-        with open(dest, "wb") as file_obj:
+        elif os.path.isdir(str(dest)):  # wrapping in str is for Python 3.5
+            dest = type(dest)(os.path.join(str(dest), real_file_name))
+        with open(str(dest), "wb") as file_obj:
             shutil.copyfileobj(request_obj, file_obj)
-    # SUpport for 2.7
-    except:
-        raise
-    finally:
-        if not six.PY2:
-            request_obj.close()
-    # end
     return dest
-
-
-def iterdir(directory="."):
-    """Iterate the directories.
-
-    Parameters
-    ----------
-    directory : str or path-like
-        The path of the directory
-
-    Returns
-    -------
-    Generator of the paths of files and directories in the `directory`
-
-    Examples
-    --------
-    >>> sorted(iterdir("/bin"))[:4]
-    ['/bin/bash', '/bin/bunzip2', '/bin/busybox', '/bin/bzcat']
-    """
-    return (os.path.join(directory, path) for path in os.listdir(directory))
-
-
-def stem(path):
-    """Returns the part of the path of the given file without the extension and
-    the path of the directory where it is in.
-
-    Parameters
-    ----------
-    path : str or path-like
-        The path of the file
-
-    Returns
-    -------
-    The file name without the extension
-
-    Examples
-    --------
-    >>> stem("/etc/ldap.conf")
-    'ldap'
-    """
-    return os.path.splitext(os.path.basename(path))[0]
-
-
-def makedirs(path, exist_ok=False):
-    """Backport of os.makedirs for Python 2.7"""
-    if six.PY2:
-        try:
-            os.makedirs(path)
-        except OSError as exception:
-            if exist_ok and exception.errno == errno.EEXIST\
-                    and os.path.isdir(path):
-                pass
-            else:
-                raise
-    else:
-        os.makedirs(path, exist_ok=exist_ok)
-
-
-def unpack_archive(archive_path, dest=None):
-    """Backport of shutil.unpack_archive for Python 2.7
-
-    Parameters
-    ----------
-    archive_path : str or path-like
-        The path of the archive file
-    dest : str or path-like or None
-        The directory where `archive_path` is extracted
-
-    Notes
-    -----
-    This function supports only ZIP archives provisionally.
-    """
-
-    if os.path.splitext(archive_path)[1].lower() != ".zip":
-        raise ValueError("{} is not a ZIP file".format(archive_path))
-    with ZipFile(archive_path) as archive_obj:
-        archive_obj.extractall(dest)
 
 
 if __name__ == "__main__":
@@ -162,19 +67,16 @@ if __name__ == "__main__":
     does_by_force = args["--force"]
     does_minimally = args["--minimal"]
 
-    base_dir = os.path.dirname(sys.argv[0])
-    wav_root_dir = os.path.join(base_dir, "data", "wav")
+    base_dir = Path(__file__).parent
+    wav_root_dir = base_dir / "data" / "wav"
 
-    if does_minimally and list(filter(os.path.isdir, iterdir(wav_root_dir))):
+    if does_minimally and list(filter(Path.is_dir, wav_root_dir.iterdir())):
         if is_verbose:
             print("There are some directories in:", wav_root_dir)
         exit(0)
 
-    # If support of 2.7 is dropped, replace the folloing 2 linee with:
-    # with TemporaryDirectory() as working_dir:
-    try:
-        working_dir = mkdtemp()
-        # end of replacement
+    with TemporaryDirectory() as working_dir:
+        working_dir = Path(working_dir)
         if is_verbose:
             print("Downloading the evaluation data...")
         eval_archive_path = download(
@@ -182,19 +84,18 @@ if __name__ == "__main__":
             "evaluation_all.zip?sequence=7&isAllowed=y", working_dir)
         if is_verbose:
             print("Unpack:", eval_archive_path)
-        unpack_archive(eval_archive_path, working_dir)
+        shutil.unpack_archive(str(eval_archive_path), str(working_dir))
         for directory in filter(
-                os.path.isdir, iterdir(os.path.join(
-                    working_dir, stem(eval_archive_path)))):
+                Path.is_dir, (working_dir / eval_archive_path.stem).iterdir()):
             if is_verbose:
                 print("Move:", directory)
-            dest_dir = os.path.join(wav_root_dir, os.path.basename(directory))
-            makedirs(dest_dir, exist_ok=does_by_force)
-            for wav_file in iglob(os.path.join(directory, "*.wav")):
-                dest_path = os.path.join(dest_dir, os.path.basename(wav_file))
-                if os.path.exists(dest_path) and does_by_force:
-                    os.remove(dest_path)
-                shutil.move(wav_file, dest_path)
+            dest_dir = wav_root_dir / directory.name
+            os.makedirs(str(dest_dir), exist_ok=does_by_force)
+            for wav_file in directory.glob("*.wav"):
+                dest_path = dest_dir / wav_file.name
+                if dest_path.exists() and does_by_force:
+                    dest_path.unlink()
+                shutil.move(str(wav_file), str(dest_path))
 
         if is_verbose:
             print("Downloading the training data...")
@@ -203,23 +104,15 @@ if __name__ == "__main__":
             "vcc2016_training.zip?sequence=8&isAllowed=y", working_dir)
         if is_verbose:
             print("Unpack:", train_archive_path)
-        unpack_archive(train_archive_path, working_dir)
+        shutil.unpack_archive(str(train_archive_path), str(working_dir))
         for directory in filter(
-                os.path.isdir, iterdir(os.path.join(working_dir, stem(
-                    train_archive_path)))):
+                Path.is_dir, (working_dir / train_archive_path.stem).iterdir()):
             if is_verbose:
                 print("Move:", directory)
-            dest_dir = os.path.join(wav_root_dir, os.path.basename(directory))
-            # exist_ok is always True because we have to append wav files in
-            # existing directories
-            makedirs(dest_dir, exist_ok=True)
-            for wav_file in iglob(os.path.join(directory, "*.wav")):
-                dest_path = os.path.join(dest_dir, os.path.basename(wav_file))
-                if os.path.exists(dest_path) and does_by_force:
-                    os.remove(dest_path)
-                shutil.move(wav_file, dest_path)
-    # If support of 2.7 dropped, remove all of the following lines
-    except:
-        raise
-    finally:
-        shutil.rmtree(working_dir)
+            dest_dir = wav_root_dir / directory.name
+            os.makedirs(str(dest_dir), exist_ok = True)
+            for wav_file in directory.glob("*.wav"):
+                dest_path=dest_dir / wav_file.name
+                if dest_path.exists() and does_by_force:
+                    dest_path.unlink()
+                shutil.move(str(wav_file), str(dest_path))

--- a/example/run_f0_transformation.py
+++ b/example/run_f0_transformation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """An example script to transform F0
 
@@ -16,55 +16,41 @@ Note:
     that are to be executed is required.
 """
 
-from __future__ import division  # , unicode_literals
-from __future__ import absolute_import, print_function
-
 import os
 import sys
+from pathlib import Path
 
 from docopt import docopt
-import six
 
 from run_sprocket import list_lengths_are_all_same
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "src"))  # isort:skip
 from src.f0_transformation import main  # isort:skip # pylint: disable=C0413
 
-if six.PY2:
-    # pylint: disable=unused-import, redefined-builtin, import-error, line-too-long
-    from future_builtins import ascii, filter, hex, map, oct, zip
-    # pylint: disable=unused-import, redefined-builtin, import-error, line-too-long, ungrouped-imports
-    from six.moves import range, input
-if six.PY3:
-    # pylint: disable=unused-import, redefined-builtin, import-error, line-too-long
-    from six.moves import reduce
 
 LIST_SUFFIXES = {
     use: "_" + use + ".list" for use in ("train", "eval")}
 
-EXAMPLE_ROOT_DIR = os.path.dirname(__file__)
-CONF_DIR = os.path.join(EXAMPLE_ROOT_DIR, "conf")
-DATA_DIR = os.path.join(EXAMPLE_ROOT_DIR, "data")
-LIST_DIR = os.path.join(EXAMPLE_ROOT_DIR, "list")
-WAV_DIR = os.path.join(DATA_DIR, "wav")
+EXAMPLE_ROOT_DIR = Path(__file__).parent
+CONF_DIR = EXAMPLE_ROOT_DIR / "conf"
+DATA_DIR = EXAMPLE_ROOT_DIR / "data"
+LIST_DIR = EXAMPLE_ROOT_DIR / "list"
+WAV_DIR = DATA_DIR / "wav"
 
 if __name__ == "__main__":
     args = docopt(__doc__)  # pylint: disable=invalid-name
     LABELS = {label: args[label.upper()] for label in ("source", "target")}
     SOURCE_TARGET_PAIR = LABELS["source"] + "-" + LABELS["target"]
-    PAIR_DIR = os.path.join(DATA_DIR, "pair",
-                            SOURCE_TARGET_PAIR)
+    PAIR_DIR = DATA_DIR / "pair" / SOURCE_TARGET_PAIR
     LIST_FILES = {
         speaker_part: {
-            use: os.path.join(LIST_DIR, speaker_label + LIST_SUFFIXES[use])
+            use: LIST_DIR / (speaker_label + LIST_SUFFIXES[use])
             for use in ("train", "eval")}
         for speaker_part, speaker_label in LABELS.items()}
     SPEAKER_CONF_FILES = {
-        part: os.path.join(
-            CONF_DIR, "speaker", label + ".yml")
+        part: CONF_DIR / "speaker" / (label + ".yml")
         for part, label in LABELS.items()}
-    PAIR_CONF_FILE = os.path.join(
-        CONF_DIR, "pair", SOURCE_TARGET_PAIR + ".yml")
+    PAIR_CONF_FILE = CONF_DIR / "pair" / (SOURCE_TARGET_PAIR + ".yml")
     f0rate = args['--f0rate']
 
     # check list file
@@ -75,8 +61,8 @@ if __name__ == "__main__":
     print("### 1. F0 transformation of original waveform ###")
     # transform F0 of waveform of original speaker
     main("--f0rate", f0rate,
-         LABELS["source"], os.path.join(SPEAKER_CONF_FILES["source"]),
-         os.path.join(SPEAKER_CONF_FILES["target"]),
-         LIST_FILES["source"]["train"],
-         LIST_FILES["source"]["eval"], LIST_FILES["target"]["train"], WAV_DIR)
+         LABELS["source"], str(SPEAKER_CONF_FILES["source"]),
+         str(SPEAKER_CONF_FILES["target"]),
+         str(LIST_FILES["source"]["train"]),
+         str(LIST_FILES["source"]["eval"]), str(LIST_FILES["target"]["train"]), str(WAV_DIR))
     print("# F0 transformed waveforms are generated #")

--- a/example/src/convert.py
+++ b/example/src/convert.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -6,21 +6,20 @@ Conversion
 
 """
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 import sys
-import numpy as np
 
+import numpy as np
 from scipy.io import wavfile
 from sklearn.externals import joblib
 
-from .yml import PairYML, SpeakerYML
-from .misc import low_cut_filter
+from sprocket.model import GV, F0statistics, GMMConvertor
 from sprocket.speech import FeatureExtractor, Synthesizer
-from sprocket.model import GMMConvertor, F0statistics, GV
-from sprocket.util import static_delta, HDF5
+from sprocket.util import HDF5, static_delta
+
+from .misc import low_cut_filter
+from .yml import PairYML, SpeakerYML
 
 
 def main(*argv):

--- a/example/src/estimate_feature_statistics.py
+++ b/example/src/estimate_feature_statistics.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -6,15 +6,14 @@ Estimate acoustic feature statistics
 
 """
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 import sys
 
-from .misc import read_feats
-from sprocket.model import F0statistics, GV
+from sprocket.model import GV, F0statistics
 from sprocket.util import HDF5
+
+from .misc import read_feats
 
 
 def main(*argv):

--- a/example/src/estimate_twf_and_jnt.py
+++ b/example/src/estimate_twf_and_jnt.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -6,18 +6,18 @@ Estimate joint feature vector of the speaker pair using GMM
 
 """
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 import sys
+
 import numpy as np
 from sklearn.externals import joblib
 
-from .misc import read_feats
+from sprocket.model.GMM import GMMConvertor, GMMTrainer
+from sprocket.util import HDF5, estimate_twf, extfrm, melcd, static_delta
 from yml import PairYML
-from sprocket.util import static_delta, extfrm, estimate_twf, melcd, HDF5
-from sprocket.model.GMM import GMMTrainer, GMMConvertor
+
+from .misc import read_feats
 
 
 def get_aligned_jointdata(orgdata, orgnpow, tardata, tarnpow, cvdata=None):

--- a/example/src/extract_features.py
+++ b/example/src/extract_features.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -13,10 +13,11 @@ import sys
 import numpy as np
 from scipy.io import wavfile
 
-from .yml import SpeakerYML
-from .misc import low_cut_filter
 from sprocket.speech import FeatureExtractor, Synthesizer
 from sprocket.util import HDF5
+
+from .misc import low_cut_filter
+from .yml import SpeakerYML
 
 
 def main(*argv):

--- a/example/src/f0_transformation.py
+++ b/example/src/f0_transformation.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 
@@ -14,8 +14,8 @@ import sys
 import numpy as np
 from scipy.io import wavfile
 
-from sprocket.speech import FeatureExtractor, Shifter
 from sprocket.model import F0statistics
+from sprocket.speech import FeatureExtractor, Shifter
 
 from .misc import low_cut_filter
 from .yml import SpeakerYML

--- a/example/src/initialize_speaker.py
+++ b/example/src/initialize_speaker.py
@@ -1,12 +1,10 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
 Generate F0 histogram to decide F0 range of the speaker
 
 """
-
-from __future__ import absolute_import, division, print_function
 
 import argparse
 import os

--- a/example/src/misc.py
+++ b/example/src/misc.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import os
+
 from scipy.signal import firwin, lfilter
+
 from sprocket.util import HDF5
 
 

--- a/example/src/train_GMM.py
+++ b/example/src/train_GMM.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -6,18 +6,18 @@ Train GMM and converted GV statistics
 
 """
 
-from __future__ import absolute_import, division, print_function
-
 import argparse
 import os
 import sys
+
 import numpy as np
 from sklearn.externals import joblib
 
-from .misc import read_feats
-from sprocket.model import GMMTrainer, GMMConvertor, GV
+from sprocket.model import GV, GMMConvertor, GMMTrainer
 from sprocket.util import HDF5, static_delta
 from yml import PairYML
+
+from .misc import read_feats
 
 
 def feature_conversion(pconf, org_mceps, gmm, gmmmode=None):

--- a/example/src/yml.py
+++ b/example/src/yml.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import os
+
 import yaml
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ dtw
 fastdtw
 nose
 pyyaml
-six
 docopt

--- a/sprocket/model/GMM.py
+++ b/sprocket/model/GMM.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 import scipy.sparse
 import sklearn.mixture

--- a/sprocket/model/GMM.py
+++ b/sprocket/model/GMM.py
@@ -206,7 +206,7 @@ class GMMConvertor(object):
 
             # conditional mean vector sequence
             mseq[t] = self.meanY[m] + \
-                np.dot(self.A[m], sddata[t] - self.meanX[m])
+                self.A[m] @ (sddata[t] - self.meanX[m])
 
             # conditional covariance sequence
             covseq[t] = self.cond_cov_inv[m]
@@ -222,7 +222,7 @@ class GMMConvertor(object):
             for m in range(self.n_mix):
                 odata[t] += wseq[t, m] * \
                     (self.meanY[m] +
-                     np.dot(self.A[m], sddata[t] - self.meanX[m]))
+                     self.A[m] @ (sddata[t] - self.meanX[m]))
 
         # retern static and throw away delta component
         return odata[:, :sddim // 2]
@@ -238,13 +238,13 @@ class GMMConvertor(object):
         D = get_diagonal_precision_matrix(T, sddim, covseq)
 
         # calculate W'D
-        WD = W.T.dot(D)
+        WD = W.T @ D
 
         # W'DW
-        WDW = WD.dot(W)
+        WDW = WD @ W
 
         # W'Um
-        WDm = WD.dot(mseq.flatten())
+        WDm = WD @ mseq.flatten()
 
         # estimate y = (W'DW)^-1 * W'Dm
         odata = scipy.sparse.linalg.spsolve(
@@ -299,15 +299,15 @@ class GMMConvertor(object):
         self.cond_cov_inv = np.zeros((self.n_mix, sddim, sddim))
         for m in range(self.n_mix):
             # calculate A (i.e., A = yxcov_m * xxcov_m^-1)
-            self.A[m] = np.dot(self.covYX[m], self.covXXinv[m])
+            self.A[m] = self.covYX[m] @ self.covXXinv[m]
 
             # calculate b (i.e., b = mean^Y - A * mean^X)
-            self.b[m] = self.meanY[m] - np.dot(self.A[m], self.meanX[m])
+            self.b[m] = self.meanY[m] - self.A[m] @ self.meanX[m]
 
             # calculate conditional covariance
             # (i.e., cov^(Y|X)^-1 = (yycov - A * xycov)^-1)
             self.cond_cov_inv[m] = np.linalg.inv(self.covYY[
-                m] - np.dot(self.A[m], self.covXY[m]))
+                m] - self.A[m] @ self.covXY[m])
 
         return
 
@@ -339,8 +339,7 @@ class GMMConvertor(object):
         self.meanX = self.meanX
         self.meanY = self.meanX
         self.covXX = self.covXX
-        self.covXY = np.dot(
-            self.covXY, np.linalg.solve(self.covYY, self.covYX))
+        self.covXY @= np.linalg.solve(self.covYY, self.covYX)
         self.covYX = self.covXY
         self.covYY = self.covXX
         return

--- a/sprocket/model/f0statistics.py
+++ b/sprocket/model/f0statistics.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 
 

--- a/sprocket/model/gv.py
+++ b/sprocket/model/gv.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 
 

--- a/sprocket/model/tests/test_GMM.py
+++ b/sprocket/model/tests/test_GMM.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import unittest
 
 import numpy as np

--- a/sprocket/model/tests/test_f0stats.py
+++ b/sprocket/model/tests/test_f0stats.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import unittest
 
 import numpy as np

--- a/sprocket/model/tests/test_gv.py
+++ b/sprocket/model/tests/test_gv.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, absolute_import
-
 import unittest
 
 import numpy as np

--- a/sprocket/speech/analyzer.py
+++ b/sprocket/speech/analyzer.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import pyworld
 
 

--- a/sprocket/speech/feature_extractor.py
+++ b/sprocket/speech/feature_extractor.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import pysptk
 import pyworld
 import numpy as np

--- a/sprocket/speech/parameterizer.py
+++ b/sprocket/speech/parameterizer.py
@@ -1,7 +1,5 @@
 # coding: utf-8
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 
 

--- a/sprocket/speech/synthesizer.py
+++ b/sprocket/speech/synthesizer.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 import pyworld
 import pysptk

--- a/sprocket/util/delta.py
+++ b/sprocket/util/delta.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 import scipy.sparse
 

--- a/sprocket/util/distance.py
+++ b/sprocket/util/distance.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 
 

--- a/sprocket/util/hdf5.py
+++ b/sprocket/util/hdf5.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import os
 import h5py
 

--- a/sprocket/util/twf.py
+++ b/sprocket/util/twf.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 from dtw import dtw
 from fastdtw import fastdtw

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,35 +5,13 @@ box: python
 # Once we can switch to Travis, we can simplify the testing steps.
 build:
   steps:
-    # Python2.7
-    - script:
-        name: py27 setup environment
-        code: |
-          wget http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh -O miniconda.sh;
-          bash miniconda.sh -b -p $HOME/miniconda
-          export PATH="$HOME/miniconda/bin:$PATH"
-          conda config --set always_yes yes --set changeps1 no
-          conda update -q conda
-          conda create -q -n test-py27-environment "python=2.7" numpy cython nose
-          source activate test-py27-environment
-
-    - script:
-        name: py27 pip install
-        code: |
-          pip install -e .
-
-    - script:
-        name: py27 nosetests
-        code: |
-          nosetests  -s -v
-
     # Python3.6
     - script:
         name: py36 setup environment
         code: |
           wget http://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86_64.sh -O miniconda.sh;
           bash miniconda.sh -b -p $HOME/miniconda3
-          source activate root          
+          source activate root
           export PATH="$HOME/miniconda3/bin:$PATH"
           conda config --set always_yes yes --set changeps1 no
           conda update -q conda


### PR DESCRIPTION
- Use pathlib.Path that is available since Python 3.4
- Remove `from __future__ import *`
- Remove `six` dependency
- Remove other Py2.7 dependencies in example
- Replace `np.dot` with `@` operator

After this PR let's close #84 