### PR TITLE
bugfix for intra-GMM conversion

### DIFF
--- a/sprocket/model/GMM.py
+++ b/sprocket/model/GMM.py
@@ -339,7 +339,7 @@ class GMMConvertor(object):
         self.meanX = self.meanX
         self.meanY = self.meanX
         self.covXX = self.covXX
-        self.covXY @= np.linalg.solve(self.covYY, self.covYX)
+        self.covXY = self.covXY @ np.linalg.solve(self.covYY, self.covYX)
         self.covYX = self.covXY
         self.covYY = self.covXX
         return


### PR DESCRIPTION
```
@=
```
行列積と代入を実行する演算子の処理は未実装の様です．