### PR TITLE
Fix URL of badge of Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python Version](https://img.shields.io/badge/Python-3.5,%203.6-green.svg)](https://img.shields.io/badge/Python-3.5,%203.6-green.svg)
+[![Python Version](https://img.shields.io/badge/Python-3.5%2C%203.6-green.svg)](https://img.shields.io/badge/Python-3.5%2C%203.6-green.svg)
 [![Build Status](https://www.travis-ci.org/k2kobayashi/sprocket.svg?branch=travis)](https://www.travis-ci.org/k2kobayashi/sprocket)
 [![Coverage Status](https://coveralls.io/repos/github/k2kobayashi/sprocket/badge.svg?branch=master)](https://coveralls.io/github/k2kobayashi/sprocket?branch=master)
 [![PyPI Version](http://img.shields.io/pypi/v/{{sprocket}}.svg)](https://pypi.python.org/pypi/{{sprocket}})


### PR DESCRIPTION
You must escape not only ` ` (`0x20`) but also `,` (`0x2C`) in the URL of ![badge of Python version](https://img.shields.io/badge/Python-3.5%2C%203.6-green.svg) in README.