### PR TITLE
Make it safer to load YAML in /example/download_speech_corpus.py

### DIFF
--- a/example/download_speech_corpus.py
+++ b/example/download_speech_corpus.py
@@ -468,7 +468,7 @@ class Downloader:
     """
     def __init__(self, config_path, user_option):
         with open(config_path) as f:
-            self.all_configs = yaml.load(f)
+            self.all_configs = yaml.safe_load(f)
         self.user_option = user_option
         self.global_config = GlobalConfiguration(
             self.all_configs.get("config", {})


### PR DESCRIPTION
`yaml.load` without designating `Loader` argument complains:

```
download_speech_corpus.py:471: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  self.all_configs = yaml.load(f)
```

`yaml.safe_load` is equivalent to `yaml.load` designating `Loader` as safe one.