### PR TITLE
Support "with statement" in sprocket.util.HDF5

### DIFF
--- a/sprocket/util/hdf5.py
+++ b/sprocket/util/hdf5.py
@@ -100,3 +100,9 @@ class HDF5(object):
         self.h5.close()
 
         return
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()

--- a/sprocket/util/tests/test_hdf5.py
+++ b/sprocket/util/tests/test_hdf5.py
@@ -32,6 +32,10 @@ class hdf5FunctionsTest(unittest.TestCase):
         assert np.allclose(tmp1d, data1d)
         assert np.allclose(tmp2d, data2d)
 
+        # open test with 'with' statement
+        with HDF5(path, 'r') as h5_with:
+            assert np.allclose(h5_with.read('1d'), data1d)
+
         # read/write and replace test
         h5 = HDF5(path, 'a')
         tmp1d = h5.read(ext='1d')


### PR DESCRIPTION
This PR enables `sprocket.util.HDF5` to be used in `with` statement like `open()` and `tempfile.TemporaryDirectory()`.

```py3
from sprocket.util import HDF5

with HDF5("./foo.h5") as h5:
    h5.save([1, 2, 3], "bar")
```