### PR TITLE
Added misc utilities to convert f0 to continuous f0

### DIFF
--- a/example/src/misc.py
+++ b/example/src/misc.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import numpy as np
 from scipy.signal import firwin, lfilter
+from scipy.interpolate import interp1d
 
 from sprocket.util import HDF5, extfrm, static_delta
 
@@ -24,6 +26,7 @@ def low_cut_filter(x, fs, cutoff=70):
     ---------
     lcf_x : array, shape(`samples`)
         Low cut filtered waveform sequence
+
     """
 
     nyquist = fs // 2
@@ -101,3 +104,77 @@ def transform_jnt(array_list):
         else:
             jnt = np.r_[jnt, array_list[i]]
     return jnt
+
+
+def low_pass_filter(x, fs, cutoff=20):
+    """Low pass filter
+
+    Paramters
+    ---------
+    x : array, shape (`N`,)
+        Waveform sequence
+    fs : int
+        Sampling frequency
+    cutoff : float, optional
+        Cutoff frequency of low pass filter
+
+    Returns
+    -------
+    lpf_x : array, shape (`N`,)
+        Low pass filtered waveform sequence
+
+    """
+    nyquist = fs // 2
+    norm_cutoff = cutoff / nyquist
+
+    # low cut filter
+    numtaps = 255
+    fil = firwin(numtaps, norm_cutoff)
+    x_pad = np.pad(x, (numtaps, numtaps), 'edge')
+    lpf_x = lfilter(fil, 1, x_pad)
+    lpf_x = lpf_x[numtaps + numtaps // 2: -numtaps // 2]
+
+    return lpf_x
+
+
+def convert_to_continuos_f0(f0):
+    """Conversion from f0 to continuous f0
+
+    Paramters
+    ---------
+    f0 : array, shape (`T`,)
+        F0 sequence
+
+    Returns
+    -------
+    uv : array, shape (`T`,)
+        U/V binary sequence
+    cont_f0 : array, shape (`T`,)
+        Continuous f0 sequence
+
+    """
+    # get uv information as binary
+    uv = np.float32(f0 != 0)
+
+    # get start and end of f0
+    if (f0 == 0).all():
+        logging.warning("all of the f0 values are 0.")
+        return uv, f0
+    start_f0 = f0[f0 != 0][0]
+    end_f0 = f0[f0 != 0][-1]
+
+    # padding start and end of f0 sequence
+    start_idx = np.where(f0 == start_f0)[0][0]
+    end_idx = np.where(f0 == end_f0)[0][-1]
+    f0[:start_idx] = start_f0
+    f0[end_idx:] = end_f0
+
+    # get non-zero frame index
+    nz_frames = np.where(f0 != 0)[0]
+
+    # perform linear interpolation
+    f = interp1d(nz_frames, f0[nz_frames])
+    cont_f0 = f(np.arange(0, f0.shape[0]))
+
+    return uv, cont_f0
+

--- a/example/src/misc.py
+++ b/example/src/misc.py
@@ -177,4 +177,3 @@ def convert_to_continuos_f0(f0):
     cont_f0 = f(np.arange(0, f0.shape[0]))
 
     return uv, cont_f0
-

--- a/sprocket/bin/convert_feats.py
+++ b/sprocket/bin/convert_feats.py
@@ -24,9 +24,8 @@ from sprocket.model import GV, F0statistics, GMMConvertor
 from sprocket.speech import FeatureExtractor, Synthesizer
 from sprocket.util import HDF5, static_delta
 
-from misc import low_cut_filter
+from misc import convert_to_continuos_f0, low_cut_filter, low_pass_filter
 from yml import PairYML, SpeakerYML
-from feature_extract import convert_continuos_f0
 
 
 def convert_mcep0th(mcep0th, ostats, tstats):
@@ -190,7 +189,8 @@ def main():
 
     # convert F0
     cvf0 = f0stats.convert(f0, org_f0stats, tar_f0stats)
-    uv, cvcf0 = convert_continuos_f0(cvf0)
+    uv, cvcf0 = convert_to_continuos_f0(cvf0)
+    cvcf0 = low_pass_filter(cvcf0, int(1.0 / (sconf.shiftms * 0.001)), cutoff=20)
 
     # convert mcep
     cvmcep_wopow = mcepgmm.convert(static_delta(mcep[:, 1:]),
@@ -236,7 +236,8 @@ def main():
         cvf0, _, _ = feat.analyze(wav)
         cvmcep_wGV = feat.mcep(dim=sconf.mcep_dim, alpha=sconf.mcep_alpha)
         cvcodeap = feat.codeap()
-        uv, cvcf0 = convert_continuos_f0(cvf0)
+        uv, cvcf0 = convert_to_continuos_f0(cvf0)
+        cvcf0 = low_pass_filter(cvcf0, int(1.0 / (sconf.shiftms * 0.001)), cutoff=20)
         wav = synthesizer.synthesis(cvf0,
                                     cvmcep_wGV,
                                     cvcodeap,

--- a/sprocket/bin/convert_feats.py
+++ b/sprocket/bin/convert_feats.py
@@ -190,7 +190,7 @@ def main():
     # convert F0
     cvf0 = f0stats.convert(f0, org_f0stats, tar_f0stats)
     uv, cvcf0 = convert_to_continuos_f0(cvf0)
-    cvcf0 = low_pass_filter(cvcf0, int(1.0 / (sconf.shiftms * 0.001)), cutoff=20)
+    cvcf0 = low_pass_filter(cvcf0, int(1.0 / (sconf.wav_shiftms * 0.001)), cutoff=20)
 
     # convert mcep
     cvmcep_wopow = mcepgmm.convert(static_delta(mcep[:, 1:]),
@@ -237,7 +237,7 @@ def main():
         cvmcep_wGV = feat.mcep(dim=sconf.mcep_dim, alpha=sconf.mcep_alpha)
         cvcodeap = feat.codeap()
         uv, cvcf0 = convert_to_continuos_f0(cvf0)
-        cvcf0 = low_pass_filter(cvcf0, int(1.0 / (sconf.shiftms * 0.001)), cutoff=20)
+        cvcf0 = low_pass_filter(cvcf0, int(1.0 / (sconf.wav_shiftms * 0.001)), cutoff=20)
         wav = synthesizer.synthesis(cvf0,
                                     cvmcep_wGV,
                                     cvcodeap,


### PR DESCRIPTION
This PR updates following two points:
- add `low_pass_filter` and `convert_to_continuous_f0` to `misc`
- change to use `misc` utilities instead of `wavenet_vocoder`'s one